### PR TITLE
[USERGRID-288] BUG: Query parameters not passed to WebResouce

### DIFF
--- a/stack/rest/src/test/java/org/apache/usergrid/rest/test/resource2point0/endpoints/CollectionEndpoint.java
+++ b/stack/rest/src/test/java/org/apache/usergrid/rest/test/resource2point0/endpoints/CollectionEndpoint.java
@@ -93,7 +93,7 @@ public class CollectionEndpoint extends NamedResource {
 
     public Collection get(final QueryParameters parameters, final boolean useToken){
         WebResource resource  = getResource(useToken);
-        addParametersToResource(resource, parameters);
+        resource = addParametersToResource(resource, parameters);
         ApiResponse response = resource.type( MediaType.APPLICATION_JSON_TYPE ).accept(MediaType.APPLICATION_JSON)
                 .get(ApiResponse.class);
 


### PR DESCRIPTION
Query parameters passed to request were not being properly added to WebResource