### PR TITLE
Documentation fix - link to Perl module

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -10,6 +10,7 @@
 * [Ruby on Rails gem](https://github.com/apache/incubator-usergrid/tree/master/sdks/ruby-on-rails)
 * [PHP library](https://github.com/apache/incubator-usergrid/tree/master/sdks/php)
 * [Java library](https://github.com/apache/incubator-usergrid/tree/master/sdks/java)
+* [Perl module](https://github.com/apache/incubator-usergrid/tree/master/sdks/perl)
 
 ## Tools
 [ugc — the Command-line Client](https://github.com/apache/incubator-usergrid/tree/master/ugc#usergrid-command-line-ugc)


### PR DESCRIPTION
Minor fix to include the link to the Perl module in usage.md.