### PR TITLE
Adding admin login function to Client.js

### DIFF
--- a/sdks/html5-javascript/lib/modules/Client.js
+++ b/sdks/html5-javascript/lib/modules/Client.js
@@ -552,7 +552,34 @@
       doCallback(callback, [err, response, user]);
     });
   };
-
+  
+  Usergrid.Client.prototype.adminlogin = function(username, password, callback) {
+    var self = this;
+    var options = {
+        method: "POST",
+        endpoint:'management/token',
+        body: {
+            username: username,
+            password: password,
+            grant_type: "password"
+        },
+        mQuery:true
+    };
+    self.request(options, function(err, response) {
+        var user = {};
+        if (err) {
+            if (self.logging) console.log("error trying to log adminuser in");
+        } else {
+            var options = {
+                client: self,
+                data: response.user
+            };
+            user = new Usergrid.Entity(options);
+            self.setToken(response.access_token);
+        }
+        doCallback(callback, [ err, response, user ]);
+    });
+  };
 
   Usergrid.Client.prototype.reAuthenticateLite = function(callback) {
     var self = this;


### PR DESCRIPTION
With this function developers can login as admin by adding the following code after initializing the usergrid client.
client.adminlogin("superuser","superuser");
related improvement in jira = https://issues.apache.org/jira/browse/USERGRID-167