### PR TITLE
Removed spurious character

### DIFF
--- a/stack/corepersistence/collection/src/test/java/org/apache/usergrid/persistence/collection/util/EntityHelper.java
+++ b/stack/corepersistence/collection/src/test/java/org/apache/usergrid/persistence/collection/util/EntityHelper.java
@@ -76,7 +76,7 @@ public class EntityHelper {
      * Verify that all fields in the expected are present in the returned, and have the same values
      * via .equals.  Does not recurse on object values.  Also verifies there are no additional fields
      * in the returned entity
-     * ø
+     *
      * @param expected
      * @param returned
      */


### PR DESCRIPTION
Build error:

[ERROR] /home/app/stack/corepersistence/collection/src/test/java/org/apache/usergrid/persistence/collection/util/EntityHelper.java:[79,8] error: unmappable character for encoding ASCII

Fixed by removal of spurious character.