### PR TITLE
[USERGRID-538] - improve error response for uncaught errors

### DIFF
--- a/stack/rest/src/main/java/org/apache/usergrid/rest/exceptions/AbstractExceptionMapper.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/exceptions/AbstractExceptionMapper.java
@@ -17,6 +17,10 @@
 package org.apache.usergrid.rest.exceptions;
 
 
+import org.apache.usergrid.rest.ApiResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import javax.servlet.http.HttpServletRequest;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
@@ -24,14 +28,9 @@ import javax.ws.rs.core.Response;
 import javax.ws.rs.core.Response.Status;
 import javax.ws.rs.ext.ExceptionMapper;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.apache.usergrid.rest.ApiResponse;
-
 import static javax.ws.rs.core.MediaType.APPLICATION_JSON_TYPE;
 import static javax.ws.rs.core.Response.Status.INTERNAL_SERVER_ERROR;
 import static javax.ws.rs.core.Response.Status.OK;
-
 import static org.apache.commons.lang.StringUtils.isNotBlank;
 import static org.apache.usergrid.rest.utils.JSONPUtils.isJavascript;
 import static org.apache.usergrid.rest.utils.JSONPUtils.wrapJSONPResponse;
@@ -57,7 +56,7 @@ public abstract class AbstractExceptionMapper<E extends java.lang.Throwable> imp
     @Override
     public Response toResponse( E e ) {
         // if we don't know what type of error it is then it's a 500
-        return toResponse( INTERNAL_SERVER_ERROR, e );
+        return toResponse( INTERNAL_SERVER_ERROR, (E) new UncaughtException(e) );
     }
 
 

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/exceptions/UncaughtException.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/exceptions/UncaughtException.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.usergrid.rest.exceptions;
+
+import org.apache.usergrid.persistence.model.util.UUIDGenerator;
+
+import java.util.UUID;
+
+public class UncaughtException extends Throwable {
+
+    private UUID timeUUID;
+
+    public UncaughtException(Throwable cause) {
+        super(cause);
+        this.timeUUID = UUIDGenerator.newTimeUUID();
+    }
+
+    public UUID getTimeUUID() {
+        return timeUUID;
+    }
+}


### PR DESCRIPTION
Added UncaughtException to handle uncaught errors. It creates a time uuid and it is set as error id in error response. 

Sample response, 
> {"error":"uncaught","timestamp":1428023297834,"duration":1,"error_description":"Internal Server Error","exception":"org.apache.usergrid.rest.exceptions.UncaughtException","error_id":"e97cf251-d99d-11e4-8c2e-4eff6b02c98b"}