### PR TITLE
Update <spring-java-version> to 1.0.1.RELEASE

### DIFF
--- a/stack/java-sdk-old/pom.xml
+++ b/stack/java-sdk-old/pom.xml
@@ -21,7 +21,7 @@
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <bundle.symbolicName>org.usergrid</bundle.symbolicName>
         <bundle.namespace>org.usergrid</bundle.namespace>
-        <spring-java-version>1.0.0.M4</spring-java-version>
+        <spring-java-version>1.0.1.RELEASE</spring-java-version>
         <jackson-version>1.9.2</jackson-version>
     </properties>
 


### PR DESCRIPTION
Update Maven dependency for <spring-java-version> from 1.0.0.M4 to 1.0.1.RELEASE to fix missing dependency during compilation.

Maven Central Repository only provide 'RELEASE' versions:
http://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22org.springframework.android%22%20AND%20a%3A%22spring-android-auth%22