### PR TITLE
Ensure that when external token validation is enabled, Admin Users cannot sign-up

### DIFF
--- a/stack/config/src/main/resources/usergrid-default.properties
+++ b/stack/config/src/main/resources/usergrid-default.properties
@@ -31,12 +31,15 @@
 # URL for local testing Cassandra cluster
 cassandra.url=localhost:9160
 
-#The number of thrift connections to open per cassandra node.
+# The number of thrift connections to open per cassandra node.
 cassandra.connections=50
-
 
 # Name of Cassandra cluster
 cassandra.cluster=Test Cluster
+
+# Keyspace names to be used (see also the locks keyspace below)
+cassandra.system.keyspace=Usergrid
+cassandra.application.keyspace=Usergrid_Applications
 
 cassandra.keyspace.strategy=org.apache.cassandra.locator.SimpleStrategy
 #cassandra.keyspace.strategy=org.apache.cassandra.locator.NetworkTopologyStrategy
@@ -49,18 +52,19 @@ cassandra.keyspace.replication=1
 cassandra.username=
 cassandra.password=
 
-#Read consistency level for the cassandra cluster
+# Read consistency level for the cassandra cluster
 cassandra.readcl=QUORUM
 
-#Write consistency level for the cassandra cluster
+# Write consistency level for the cassandra cluster
 cassandra.writecl=QUORUM
 
-#The maximum number of pending mutations allowed in ram before it is flushed to cassandra
+# The maximum number of pending mutations allowed in ram before it is flushed to cassandra
 cassandra.mutation.flushsize=2000
 
-#Keyspace to use for locking
-#Note that if this is deployed in a production cluster, the RF on the keyspace MUST be updated to use an odd number for it's replication Factor.
-#Even numbers for RF can potentially case the locks to fail, via "split brain" when read at QUORUM on lock verification
+# Keyspace to use for locking - Used by Hector lock manager:
+# Note that if this is deployed in a production cluster, the RF on the keyspace MUST
+# be updated to use an odd number for it's replication Factor. Even numbers for RF can
+# potentially case the locks to fail, via "split brain" when read at QUORUM on lock verification
 cassandra.lock.keyspace=Locks
 
 # false to disable test features
@@ -111,9 +115,10 @@ usergrid.sysadmin.login.allowed=false
 usergrid.sysadmin.approve.users=false
 usergrid.sysadmin.approve.organizations=false
 
-# Base URL of central Usergrid SSO server
-# Setting this will enable external token validation.
-# See also: https://issues.apache.org/jira/browse/USERGRID-567
+# Base URL of central Usergrid SSO server:
+# Setting this will enable External Token Validation for Admin Users and will configure
+# this Usergrid instance delegate all Admin User authentication to the central  Usegrid SSO
+# server. See also: https://issues.apache.org/jira/browse/USERGRID-567
 usergrid.central.url=
 
 # Where to store temporary files

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/management/organizations/OrganizationsResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/management/organizations/OrganizationsResource.java
@@ -33,6 +33,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
 
 import org.apache.usergrid.rest.RootResource;
+import org.apache.usergrid.rest.management.ManagementResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -111,9 +112,9 @@ public class OrganizationsResource extends AbstractContextResource {
         String name = ( String ) json.remove( "name" );
         String email = ( String ) json.remove( "email" );
         String password = ( String ) json.remove( "password" );
-        Map<String, Object> properties = ( Map<String, Object> ) json.remove( ORGANIZATION_PROPERTIES );
+        Map<String, Object> orgProperties = ( Map<String, Object> ) json.remove( ORGANIZATION_PROPERTIES );
 
-        return newOrganization( ui, organizationName, username, name, email, password, json, properties, callback );
+        return newOrganization( ui, organizationName, username, name, email, password, json, orgProperties, callback );
     }
 
 
@@ -146,7 +147,16 @@ public class OrganizationsResource extends AbstractContextResource {
     /** Create a new organization */
     private JSONWithPadding newOrganization( @Context UriInfo ui, String organizationName, String username, String name,
                                              String email, String password, Map<String, Object> userProperties,
-                                             Map<String, Object> properties, String callback ) throws Exception {
+                                             Map<String, Object> orgProperties, String callback ) throws Exception {
+
+        final boolean externalTokensEnabled =
+                !StringUtils.isEmpty( properties.getProperty( ManagementResource.USERGRID_CENTRAL_URL ) );
+
+        if ( externalTokensEnabled ) {
+            throw new IllegalArgumentException( "Organization / Admin Users must be created via " +
+                    properties.getProperty( ManagementResource.USERGRID_CENTRAL_URL ) );
+        }
+
         Preconditions
                 .checkArgument( StringUtils.isNotBlank( organizationName ), "The organization parameter was missing" );
 
@@ -157,7 +167,7 @@ public class OrganizationsResource extends AbstractContextResource {
 
         OrganizationOwnerInfo organizationOwner = management
                 .createOwnerAndOrganization( organizationName, username, name, email, password, false, false,
-                        userProperties, properties );
+                        userProperties, orgProperties );
 
         if ( organizationOwner == null ) {
             logger.info( "organizationOwner is null, returning. organization: {}", organizationName );

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/management/users/UserResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/management/users/UserResource.java
@@ -393,7 +393,7 @@ public class UserResource extends AbstractContextResource {
                 !StringUtils.isEmpty( properties.getProperty( ManagementResource.USERGRID_CENTRAL_URL ) );
 
         if ( externalTokensEnabled ) {
-            throw new IllegalArgumentException( "Admin Users must reactiveate via " +
+            throw new IllegalArgumentException( "Admin Users must reactivate via " +
                     properties.getProperty( ManagementResource.USERGRID_CENTRAL_URL ) );
         }
 

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/management/users/UserResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/management/users/UserResource.java
@@ -33,6 +33,8 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
 
+import org.apache.commons.lang.StringUtils;
+import org.apache.usergrid.rest.management.ManagementResource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.Scope;
@@ -205,6 +207,14 @@ public class UserResource extends AbstractContextResource {
     @Produces( MediaType.TEXT_HTML )
     public Viewable showPasswordResetForm( @Context UriInfo ui, @QueryParam( "token" ) String token ) {
 
+        final boolean externalTokensEnabled =
+                !StringUtils.isEmpty( properties.getProperty( ManagementResource.USERGRID_CENTRAL_URL ) );
+
+        if ( externalTokensEnabled ) {
+            throw new IllegalArgumentException( "Admin Users must reset passwords via " +
+                    properties.getProperty( ManagementResource.USERGRID_CENTRAL_URL ) );
+        }
+
         try {
             this.token = token;
 
@@ -233,6 +243,14 @@ public class UserResource extends AbstractContextResource {
                                              @FormParam( "password2" ) String password2,
                                              @FormParam( "recaptcha_challenge_field" ) String challenge,
                                              @FormParam( "recaptcha_response_field" ) String uresponse ) {
+
+        final boolean externalTokensEnabled =
+                !StringUtils.isEmpty( properties.getProperty( ManagementResource.USERGRID_CENTRAL_URL ) );
+
+        if ( externalTokensEnabled ) {
+            throw new IllegalArgumentException( "Admin Users must reset passwords via " +
+                    properties.getProperty( ManagementResource.USERGRID_CENTRAL_URL ) );
+        }
 
         try {
             this.token = token;
@@ -309,6 +327,14 @@ public class UserResource extends AbstractContextResource {
     @Produces( MediaType.TEXT_HTML )
     public Viewable activate( @Context UriInfo ui, @QueryParam( "token" ) String token ) {
 
+        final boolean externalTokensEnabled =
+                !StringUtils.isEmpty( properties.getProperty( ManagementResource.USERGRID_CENTRAL_URL ) );
+
+        if ( externalTokensEnabled ) {
+            throw new IllegalArgumentException( "Admin Users must activate via " +
+                    properties.getProperty( ManagementResource.USERGRID_CENTRAL_URL ) );
+        }
+
         try {
             management.handleActivationTokenForAdminUser( user.getUuid(), token );
             return handleViewable( "activate", this );
@@ -329,6 +355,14 @@ public class UserResource extends AbstractContextResource {
     @Path( "confirm" )
     @Produces( MediaType.TEXT_HTML )
     public Viewable confirm( @Context UriInfo ui, @QueryParam( "token" ) String token ) {
+
+        final boolean externalTokensEnabled =
+                !StringUtils.isEmpty( properties.getProperty( ManagementResource.USERGRID_CENTRAL_URL ) );
+
+        if ( externalTokensEnabled ) {
+            throw new IllegalArgumentException( "Admin Users must confirm via " +
+                    properties.getProperty( ManagementResource.USERGRID_CENTRAL_URL ) );
+        }
 
         try {
             ActivationState state = management.handleConfirmationTokenForAdminUser( user.getUuid(), token );
@@ -354,6 +388,14 @@ public class UserResource extends AbstractContextResource {
     public JSONWithPadding reactivate( @Context UriInfo ui,
                                        @QueryParam( "callback" ) @DefaultValue( "callback" ) String callback )
             throws Exception {
+
+        final boolean externalTokensEnabled =
+                !StringUtils.isEmpty( properties.getProperty( ManagementResource.USERGRID_CENTRAL_URL ) );
+
+        if ( externalTokensEnabled ) {
+            throw new IllegalArgumentException( "Admin Users must reactiveate via " +
+                    properties.getProperty( ManagementResource.USERGRID_CENTRAL_URL ) );
+        }
 
         logger.info( "Send activation email for user: {}" , user.getUuid() );
 

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/management/users/UsersResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/management/users/UsersResource.java
@@ -34,8 +34,10 @@ import javax.ws.rs.core.Context;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.UriInfo;
 
+import org.apache.commons.lang.StringUtils;
 import org.apache.usergrid.management.exceptions.ManagementException;
 import org.apache.usergrid.rest.RootResource;
+import org.apache.usergrid.rest.management.ManagementResource;
 import org.apache.usergrid.services.exceptions.ServiceResourceNotFoundException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,7 +80,7 @@ public class UsersResource extends AbstractContextResource {
     @Path(RootResource.USER_ID_PATH)
     public UserResource getUserById( @Context UriInfo ui, @PathParam( "userId" ) String userIdStr ) throws Exception {
 
-        return getUserResource(management.getAdminUserByUuid(UUID.fromString(userIdStr)), "user id", userIdStr);
+        return getUserResource(management.getAdminUserByUuid( UUID.fromString( userIdStr ) ), "user id", userIdStr);
     }
 
 
@@ -101,14 +103,14 @@ public class UsersResource extends AbstractContextResource {
         if (user == null) {
             throw new ManagementException("Could not find organization for " + type + " : " + value);
         }
-        return getSubResource(UserResource.class).init(user);
+        return getSubResource(UserResource.class).init( user );
     }
 
 
     @Path(RootResource.EMAIL_PATH)
     public UserResource getUserByEmail( @Context UriInfo ui, @PathParam( "email" ) String email ) throws Exception {
 
-        return getUserResource(management.getAdminUserByEmail(email), "email", email);
+        return getUserResource(management.getAdminUserByEmail( email ), "email", email);
     }
 
 
@@ -119,6 +121,14 @@ public class UsersResource extends AbstractContextResource {
                                        @FormParam( "password" ) String password,
                                        @QueryParam( "callback" ) @DefaultValue( "callback" ) String callback )
             throws Exception {
+
+        final boolean externalTokensEnabled =
+                !StringUtils.isEmpty( properties.getProperty( ManagementResource.USERGRID_CENTRAL_URL ) );
+
+        if ( externalTokensEnabled ) {
+            throw new IllegalArgumentException( "Admin Users must signup via " +
+                    properties.getProperty( ManagementResource.USERGRID_CENTRAL_URL ) );
+        }
 
         logger.info( "Create user: " + username );
 

--- a/stack/rest/src/test/java/org/apache/usergrid/rest/management/ManagementResourceIT.java
+++ b/stack/rest/src/test/java/org/apache/usergrid/rest/management/ManagementResourceIT.java
@@ -695,8 +695,11 @@ public class ManagementResourceIT extends AbstractRestIT {
                 .queryParam( "ttl", "1000" )
                 .get( JsonNode.class );
             fail("Validation should have failed");
-        } catch ( Exception actual ) {
-            logger.debug( "error", actual );
+        } catch ( UniformInterfaceException actual ) {
+            assertEquals( 400, actual.getResponse().getStatus() );
+            String errorMsg = actual.getResponse().getEntity( JsonNode.class ).get( "error_description" ).toString();
+            logger.error( "ERROR: " + errorMsg );
+            assertTrue( errorMsg.contains( "Admin Users must login via" ) );
         }
 
 

--- a/stack/rest/src/test/java/org/apache/usergrid/rest/management/ManagementResourceIT.java
+++ b/stack/rest/src/test/java/org/apache/usergrid/rest/management/ManagementResourceIT.java
@@ -696,10 +696,10 @@ public class ManagementResourceIT extends AbstractRestIT {
                 .get( JsonNode.class );
             fail("Validation should have failed");
         } catch ( UniformInterfaceException actual ) {
-            assertEquals( 400, actual.getResponse().getStatus() );
+            assertEquals( 404, actual.getResponse().getStatus() );
             String errorMsg = actual.getResponse().getEntity( JsonNode.class ).get( "error_description" ).toString();
             logger.error( "ERROR: " + errorMsg );
-            assertTrue( errorMsg.contains( "Admin Users must login via" ) );
+            assertTrue( errorMsg.contains( "Cannot find Admin User" ) );
         }
 
 

--- a/stack/rest/src/test/java/org/apache/usergrid/rest/management/ManagementResourceIT.java
+++ b/stack/rest/src/test/java/org/apache/usergrid/rest/management/ManagementResourceIT.java
@@ -669,7 +669,7 @@ public class ManagementResourceIT extends AbstractRestIT {
 
         String suToken = superAdminToken();
         Map<String, String> props = new HashMap<String, String>();
-        props.put( USERGRID_CENTRAL_URL, getBaseURI().toURL().toExternalForm());
+        props.put( USERGRID_CENTRAL_URL, getBaseURI().toURL().toExternalForm() );
         resource().path( "/testproperties" )
                 .queryParam( "access_token", suToken)
                 .accept( MediaType.APPLICATION_JSON )
@@ -722,7 +722,7 @@ public class ManagementResourceIT extends AbstractRestIT {
 
         // create an org and an admin user
 
-        String rand = RandomStringUtils.randomAlphanumeric(10);
+        String rand = RandomStringUtils.randomAlphanumeric( 10 );
         final String username = "user_" + rand;
         OrganizationOwnerInfo orgInfo = setup.getMgmtSvc().createOwnerAndOrganization(
                 username, username, "Test User", username + "@example.com", "password" );
@@ -743,17 +743,23 @@ public class ManagementResourceIT extends AbstractRestIT {
         try {
 
             Map<String, Object> loginInfo = new HashMap<String, Object>() {{
-                                                                              put("username", username );
-                                                                              put("password", "password");
-                                                                              put("grant_type", "password");
-                                                                              }};
+                put("username", username );
+                put("password", "password");
+                put("grant_type", "password");
+            }};
             JsonNode accessInfoNode = resource().path("/management/token")
                     .type( MediaType.APPLICATION_JSON_TYPE )
                     .post( JsonNode.class, loginInfo );
             fail("Login as Admin User must fail when validate external tokens is enabled");
 
-        } catch ( Exception actual ) {
-            logger.debug( "error", actual );
+        } catch ( UniformInterfaceException actual ) {
+            assertEquals( 400, actual.getResponse().getStatus() );
+            String errorMsg = actual.getResponse().getEntity( JsonNode.class ).get( "error_description" ).toString();
+            logger.error( "ERROR: " + errorMsg );
+            assertTrue( errorMsg.contains( "Admin Users must login via" ));
+
+        } catch ( Exception e ) {
+            fail( "We expected a UniformInterfaceException" );
         }
 
         // login as superuser must succeed


### PR DESCRIPTION
Or be activated or be confirmed... all that should happen via Usergrid Central.