### PR TITLE
[USERGRID-572] - ignore sensitive params from QP in response params

### DIFF
--- a/stack/rest/src/main/java/org/apache/usergrid/rest/ApiResponse.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/ApiResponse.java
@@ -24,6 +24,8 @@ import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize.Inclusion;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -84,6 +86,9 @@ public class ApiResponse {
     private ClientCredentialsInfo credentials;
 
     protected Map<String, Object> properties = new TreeMap<String, Object>( String.CASE_INSENSITIVE_ORDER );
+
+    protected final Collection<String> IGNORE_QP = Arrays.asList("client_id", "client_secret", "password", "username", "access_token",
+                    "client_credentials", "fb_access_token", "fq_access_token", "ping_access_token", "token");
 
     @Autowired
     protected ServerEnvironmentProperties serverEnvironmentProperties;
@@ -556,6 +561,7 @@ public class ApiResponse {
     public void setParams( Map<String, List<String>> params ) {
         Map<String, List<String>> q = new LinkedHashMap<String, List<String>>();
         for ( String k : params.keySet() ) {
+            if (IGNORE_QP.contains(k.toLowerCase())) continue;
             List<String> v = params.get( k );
             if ( v != null ) {
                 q.put( k, new ArrayList<String>( v ) );

--- a/stack/rest/src/test/java/org/apache/usergrid/rest/ApiResponseTest.java
+++ b/stack/rest/src/test/java/org/apache/usergrid/rest/ApiResponseTest.java
@@ -1,0 +1,45 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.usergrid.rest;
+
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+public class ApiResponseTest {
+
+    @Test
+    public void testIgnoreQP() {
+        ApiResponse apiResponse = new ApiResponse();
+        Map<String, List<String>> params = new HashMap<String, List<String>>();
+        params.put("access_token", Arrays.asList("YWMtL8AQ-ukcEeS2lHs-P-n8wQAAAU0GaCt_Y0cPWeXMJij4x_fW0w_dTMpUH7I"));
+        params.put("name", Arrays.asList("test"));
+        params.put("username", Arrays.asList("abc"));
+        params.put("password", Arrays.asList("123"));
+        apiResponse.setParams(params);
+        assertNull(apiResponse.getParams().get("password"));
+        assertEquals(apiResponse.getParams().size(), 1);
+    }
+}


### PR DESCRIPTION
Added a set of params to be ignored in response. Following params will be ignored. 

client_id, client_secret, password, username, access_token, client_credentials, fb_access_token,
fq_access_token, ping_access_token, token

Please let me know if this is okay, I'll make the change on master as well and send another PR.