### PR TITLE
579 - alternative to the S3BinaryStore class

### DIFF
--- a/docs/file-storage-configuration.md
+++ b/docs/file-storage-configuration.md
@@ -1,0 +1,52 @@
+# File storage configuration
+
+Usergrid can store your assets either on your hard drive or in the Amazon S3 cloud.
+
+Local storage configuration
+---
+
+By default assets are stored in the temporary folder /tmp/usergrid
+to change this
+
+
+This is an alternative to the S3BinaryStore class in Usergrid.
+It has several advantages :
+ - upload files up to 50GB
+ - support of V4 signing process
+ - lower network latency when a regionName is defined
+
+To use it add following dependency in stack/pom.xml
+
+```xml
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-s3</artifactId>
+        <version>1.9.31</version>
+      </dependency>
+```
+and stack/services/pom.xml
+```xml
+    <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+    </dependency>
+```
+then add the AwsSdkS3BinaryStore.java file in the /stack/services/src/main/java/org/apache/usergrid/services/assets/data/ folder.
+
+finaly define the new classpath in the /stack/rest/src/main/resources/usergrid-rest-context.xml file
+```xml
+    <bean id="binaryStore" class="org.apache.usergrid.services.assets.data.AwsSdkS3BinaryStore">
+        <constructor-arg name="accessId" value="x" />
+        <constructor-arg name="secretKey" value="xx" />
+        <constructor-arg name="bucketName" value="x" />
+        <constructor-arg name="regionName" value="eu-central-1" />
+    </bean>
+```
+the regionName field is not mandatory, this code is also valid
+```xml
+    <bean id="binaryStore" class="org.apache.usergrid.services.assets.data.AwsSdkS3BinaryStore">
+        <constructor-arg name="accessId" value="x" />
+        <constructor-arg name="secretKey" value="xx" />
+        <constructor-arg name="bucketName" value="x" />
+    </bean>
+```

--- a/docs/file-storage-configuration.md
+++ b/docs/file-storage-configuration.md
@@ -6,47 +6,34 @@ Local storage configuration
 ---
 
 By default assets are stored in the temporary folder /tmp/usergrid
-to change this
-
-
-This is an alternative to the S3BinaryStore class in Usergrid.
-It has several advantages :
- - upload files up to 50GB
- - support of V4 signing process
- - lower network latency when a regionName is defined
-
-To use it add following dependency in stack/pom.xml
-
+This can be changed by editing this file /stack/rest/src/main/resources/usergrid-rest-context.xml and replacing {usergrid.temp.files} by the wanted destination
 ```xml
-      <dependency>
-        <groupId>com.amazonaws</groupId>
-        <artifactId>aws-java-sdk-s3</artifactId>
-        <version>1.9.31</version>
-      </dependency>
+<bean id="binaryStore" class="org.apache.usergrid.services.assets.data.LocalFileBinaryStore">
+  <property name="reposLocation" value="${usergrid.temp.files}"/>
+</bean>
 ```
-and stack/services/pom.xml
-```xml
-    <dependency>
-      <groupId>com.amazonaws</groupId>
-      <artifactId>aws-java-sdk-s3</artifactId>
-    </dependency>
-```
-then add the AwsSdkS3BinaryStore.java file in the /stack/services/src/main/java/org/apache/usergrid/services/assets/data/ folder.
 
-finaly define the new classpath in the /stack/rest/src/main/resources/usergrid-rest-context.xml file
+AwS S3 configuration
+---
+
+To use your AWS S3 storage you need to change the binaryStore classpath and add several constructor arguments in /stack/rest/src/main/resources/usergrid-rest-context.xml
+
+Some examples :
 ```xml
-    <bean id="binaryStore" class="org.apache.usergrid.services.assets.data.AwsSdkS3BinaryStore">
-        <constructor-arg name="accessId" value="x" />
-        <constructor-arg name="secretKey" value="xx" />
-        <constructor-arg name="bucketName" value="x" />
-        <constructor-arg name="regionName" value="eu-central-1" />
-    </bean>
+<bean id="binaryStore" class="org.apache.usergrid.services.assets.data.AwsSdkS3BinaryStore">
+  <constructor-arg name="accessId" value="x" />
+  <constructor-arg name="secretKey" value="xx" />
+  <constructor-arg name="bucketName" value="x" />
+  <constructor-arg name="regionName" value="eu-central-1" />
+</bean>
 ```
 the regionName field is not mandatory, this code is also valid
 ```xml
-    <bean id="binaryStore" class="org.apache.usergrid.services.assets.data.AwsSdkS3BinaryStore">
-        <constructor-arg name="accessId" value="x" />
-        <constructor-arg name="secretKey" value="xx" />
-        <constructor-arg name="bucketName" value="x" />
-    </bean>
+<bean id="binaryStore" class="org.apache.usergrid.services.assets.data.AwsSdkS3BinaryStore">
+  <constructor-arg name="accessId" value="x" />
+  <constructor-arg name="secretKey" value="xx" />
+  <constructor-arg name="bucketName" value="x" />
+</bean>
 ```
+
+The filesize is limited to 50GB but you need to keep in mind that the file has to be stored on the hard drive before being sended to Amazon.

--- a/stack/pom.xml
+++ b/stack/pom.xml
@@ -156,7 +156,7 @@
     </developer>
   </developers>
 
-  <modules>
+  <modules>ht
     <module>java-sdk-old</module>
     <module>config</module>
     <module>core</module>
@@ -241,6 +241,13 @@
           </exclusion>
         </exclusions>
       </dependency>
+      
+      <dependency>
+        <groupId>com.amazonaws</groupId>
+        <artifactId>aws-java-sdk-s3</artifactId>
+        <version>1.9.31</version>
+      </dependency>
+
 
       <dependency>
         <groupId>org.apache.activemq</groupId>

--- a/stack/pom.xml
+++ b/stack/pom.xml
@@ -156,7 +156,7 @@
     </developer>
   </developers>
 
-  <modules>ht
+  <modules>
     <module>java-sdk-old</module>
     <module>config</module>
     <module>core</module>

--- a/stack/pom.xml
+++ b/stack/pom.xml
@@ -233,7 +233,7 @@
       <dependency>
         <groupId>org.apache.httpcomponents</groupId>
         <artifactId>httpclient</artifactId>
-        <version>4.1.3</version>
+        <version>4.4.1</version>
         <exclusions>
           <exclusion>
             <groupId>commons-codec</groupId>

--- a/stack/services/pom.xml
+++ b/stack/services/pom.xml
@@ -399,6 +399,11 @@
     </dependency>
 
     <dependency>
+      <groupId>com.amazonaws</groupId>
+      <artifactId>aws-java-sdk-s3</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>org.apache.jclouds</groupId>
       <artifactId>jclouds-blobstore</artifactId>
     </dependency>

--- a/stack/services/src/main/java/org/apache/usergrid/services/assets/data/AwsSdkS3BinaryStore.java
+++ b/stack/services/src/main/java/org/apache/usergrid/services/assets/data/AwsSdkS3BinaryStore.java
@@ -1,0 +1,230 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.usergrid.services.assets.data;
+
+
+import java.io.BufferedOutputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.Map;
+import java.util.UUID;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.apache.usergrid.persistence.Entity;
+import org.apache.usergrid.persistence.EntityManagerFactory;
+
+import org.apache.commons.codec.binary.Hex;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.io.IOUtils;
+
+import com.amazonaws.ClientConfiguration;
+import com.amazonaws.Protocol;
+import com.amazonaws.auth.AWSCredentials;
+import com.amazonaws.auth.BasicAWSCredentials;
+import com.amazonaws.regions.Region;
+import com.amazonaws.regions.Regions;
+import com.amazonaws.services.s3.AmazonS3;
+import com.amazonaws.services.s3.AmazonS3Client;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadRequest;
+import com.amazonaws.services.s3.model.CompleteMultipartUploadResult;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadRequest;
+import com.amazonaws.services.s3.model.InitiateMultipartUploadResult;
+import com.amazonaws.services.s3.model.ObjectMetadata;
+import com.amazonaws.services.s3.model.PartETag;
+import com.amazonaws.services.s3.model.PutObjectResult;
+import com.amazonaws.services.s3.model.S3Object;
+import com.amazonaws.services.s3.model.UploadPartRequest;
+import com.google.common.primitives.Ints;
+import java.io.ByteArrayInputStream;
+import java.io.FileInputStream;
+import java.io.PushbackInputStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.codec.binary.Base64;
+
+
+public class AwsSdkS3BinaryStore implements BinaryStore {
+
+    private static final Logger LOG = LoggerFactory.getLogger(AwsSdkS3BinaryStore.class );
+    private static final long FIVE_MB = ( FileUtils.ONE_MB * 5 );
+    
+    private AmazonS3 s3Client;
+    private String accessId;
+    private String secretKey;
+    private String bucketName;
+    private String regionName;
+
+    @Autowired
+    private EntityManagerFactory emf;
+
+
+    public AwsSdkS3BinaryStore( String accessId, String secretKey, String bucketName, String regionName ) {
+        this.accessId = accessId;
+        this.secretKey = secretKey;
+        this.bucketName = bucketName;
+        this.regionName = regionName;
+    }
+
+    public AwsSdkS3BinaryStore( String accessId, String secretKey, String bucketName ) {
+        this.accessId = accessId;
+        this.secretKey = secretKey;
+        this.bucketName = bucketName;
+    }
+
+    private AmazonS3 getS3Client() {
+        if ( s3Client == null ) {
+            AWSCredentials credentials = new BasicAWSCredentials(accessId, secretKey);
+            ClientConfiguration clientConfig = new ClientConfiguration();
+            clientConfig.setProtocol(Protocol.HTTP);
+
+            s3Client = new AmazonS3Client(credentials, clientConfig);
+            if(regionName != null)
+                s3Client.setRegion( Region.getRegion(Regions.fromName(regionName)) );
+        }
+
+        return s3Client;
+    }
+
+
+    @Override
+    public void write( final UUID appId, final Entity entity, InputStream inputStream ) throws IOException {
+
+        String uploadFileName = AssetUtils.buildAssetKey( appId, entity );
+        ByteArrayOutputStream baos = new ByteArrayOutputStream();
+        long written = IOUtils.copyLarge( inputStream, baos, 0, FIVE_MB );
+
+        byte[] data = baos.toByteArray();
+        
+        InputStream awsInputStream = new ByteArrayInputStream(data);
+        
+        final Map<String, Object> fileMetadata = AssetUtils.getFileMetadata( entity );
+        fileMetadata.put( AssetUtils.LAST_MODIFIED, System.currentTimeMillis() );
+
+        String mimeType = AssetMimeHandler.get().getMimeType( entity, data );
+        
+        if ( written < FIVE_MB ) { // total smaller than 5mb
+
+            ObjectMetadata om = new ObjectMetadata();
+            om.setContentLength(written);
+            om.setContentType(mimeType);
+            PutObjectResult result = getS3Client().putObject(bucketName, uploadFileName, awsInputStream, om);
+            
+            String md5sum = Hex.encodeHexString( Base64.decodeBase64(result.getContentMd5()) );
+            String eTag = result.getETag();
+            
+            fileMetadata.put( AssetUtils.CONTENT_LENGTH, written );
+
+            if(md5sum != null)
+                fileMetadata.put( AssetUtils.CHECKSUM, md5sum );
+            fileMetadata.put( AssetUtils.E_TAG, eTag );
+        }
+        else { // bigger than 5mb... dump 5 mb tmp files and upload from them
+            written = 0; //reset written to 0, we still haven't wrote anything in fact
+            int partNumber = 1;
+            int firstByte = 0;
+            Boolean isFirstChunck = true;
+            List<PartETag> partETags = new ArrayList<PartETag>();
+            
+            InitiateMultipartUploadRequest initRequest = new InitiateMultipartUploadRequest(bucketName, uploadFileName);
+            InitiateMultipartUploadResult initResponse = getS3Client().initiateMultipartUpload(initRequest);  
+            
+            InputStream firstChunck = new ByteArrayInputStream(data);
+            PushbackInputStream chunckableInputStream = new PushbackInputStream(inputStream, 1);
+
+            while (-1 != (firstByte = chunckableInputStream.read())) {
+                long partSize = 0;
+                chunckableInputStream.unread(firstByte);
+                File tempFile = File.createTempFile( entity.getUuid().toString().concat("-part").concat(String.valueOf(partNumber)), "tmp" );
+
+                tempFile.deleteOnExit();
+                OutputStream os = null;
+                try {
+                    os = new BufferedOutputStream( new FileOutputStream( tempFile.getAbsolutePath() ) );
+                    
+                    if(isFirstChunck == true) {
+                        partSize = IOUtils.copyLarge( firstChunck, os, 0, ( FIVE_MB ) );
+                        isFirstChunck = false;
+                    }
+                    else {
+                        partSize = IOUtils.copyLarge( chunckableInputStream, os, 0, ( FIVE_MB ) );
+                    }
+                    written += partSize;
+                }
+                finally {
+                    IOUtils.closeQuietly( os );
+                }
+                
+                FileInputStream chunck = new FileInputStream(tempFile);
+               
+                Boolean isLastPart = -1 == (firstByte = chunckableInputStream.read());
+                if(!isLastPart)
+                    chunckableInputStream.unread(firstByte);
+                
+                UploadPartRequest uploadRequest = new UploadPartRequest().withUploadId(initResponse.getUploadId())
+                                                                         .withBucketName(bucketName)
+                                                                         .withKey(uploadFileName)
+                                                                         .withInputStream(chunck)
+                                                                         .withPartNumber(partNumber)
+                                                                         .withPartSize(partSize)
+                                                                         .withLastPart(isLastPart);
+                partETags.add( getS3Client().uploadPart(uploadRequest).getPartETag() );
+                partNumber++;
+            }
+            
+            CompleteMultipartUploadRequest request = new CompleteMultipartUploadRequest(bucketName, uploadFileName, initResponse.getUploadId(), partETags);
+            CompleteMultipartUploadResult amazonResult = getS3Client().completeMultipartUpload(request);
+            fileMetadata.put( AssetUtils.CONTENT_LENGTH, written );
+            fileMetadata.put( AssetUtils.E_TAG, amazonResult.getETag() );
+        }
+    }
+
+
+    @Override
+    public InputStream read( UUID appId, Entity entity, long offset, long length ) throws IOException {
+        
+        S3Object object = getS3Client().getObject(bucketName,  AssetUtils.buildAssetKey( appId, entity ));        
+        byte data[] = null;
+        
+        if ( offset == 0 && length == FIVE_MB ) {
+            return object.getObjectContent();
+        }
+        else {
+            object.getObjectContent().read(data, Ints.checkedCast(offset), Ints.checkedCast(length));
+        }
+
+        return new ByteArrayInputStream(data);
+    }
+
+
+    @Override
+    public InputStream read( UUID appId, Entity entity ) throws IOException {
+        return read( appId, entity, 0, FIVE_MB );
+    }
+
+
+    @Override
+    public void delete( UUID appId, Entity entity ) {
+        getS3Client().deleteObject(new DeleteObjectRequest(bucketName, AssetUtils.buildAssetKey( appId, entity )));
+    }
+}


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/USERGRID-579

This adds the AwsSdkS3BinaryStore class, the old S3BinaryStore class will still be available. 
AwsSdkS3BinaryStore has several advantages :
 - upload files up to 50GB
 - support of V4 signing process
 - lower network latency when a regionName is defined

I tested it with an 1.2 GB file so far and checked all md5 checksums to be sure everything is fine.
Only the deleting is not working but I believe that the bug is not in the class. It appears that the binaryStore.delete() method is never called. I think it has something to do with this ticket https://issues.apache.org/jira/browse/USERGRID-530
I will make further investigations on it.

PS : My ICLA was approved.