### PR TITLE
Remove Jackson 2 dependency

### DIFF
--- a/stack/services/pom.xml
+++ b/stack/services/pom.xml
@@ -401,6 +401,12 @@
     <dependency>
       <groupId>com.amazonaws</groupId>
       <artifactId>aws-java-sdk-s3</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>jackson-databind</artifactId>
+          <groupId>com.fasterxml.jackson.core</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Remove Jackson 2 dependency that snuck in with new AWS S3 store because it breaks the rest tests.