### PR TITLE
Small fixes to Admin import/export tool based on results of testing

### DIFF
--- a/stack/services/src/main/java/org/apache/usergrid/management/cassandra/ManagementServiceImpl.java
+++ b/stack/services/src/main/java/org/apache/usergrid/management/cassandra/ManagementServiceImpl.java
@@ -1480,7 +1480,12 @@ public class ManagementServiceImpl implements ManagementService {
                 path = path.toLowerCase();
             }
 
-            organizations.put( entity.getUuid(), path );
+            try {
+                organizations.put( entity.getUuid(), path );
+            } catch (IllegalArgumentException e) {
+                logger.warn("Error adding " + entity.getUuid() + ":" + path + " to BiMap: " + e.getMessage() );
+            }
+
         }
 
         return organizations;

--- a/stack/tools/src/test/java/org/apache/usergrid/tools/ExportImportAdminsTest.java
+++ b/stack/tools/src/test/java/org/apache/usergrid/tools/ExportImportAdminsTest.java
@@ -37,10 +37,7 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileOutputStream;
 import java.io.FilenameFilter;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
 import static junit.framework.TestCase.assertNotNull;
 import static org.junit.Assert.assertEquals;
@@ -227,6 +224,11 @@ public class ExportImportAdminsTest {
 
         List<UserInfo> org2_users = setup.getMgmtSvc().getAdminUsersForOrganization( org_uuid_2 );
         assertEquals("org2 has two users", 2, org2_users.size() );
-    }
 
+        UserInfo user1info = setup.getMgmtSvc().getAdminUserByUuid( user_uuid_1 );
+        Map<String, Object> user1_data = setup.getMgmtSvc().getAdminUserOrganizationData( user1info, false );
+        Map<String, Object> user1_data_orgs = (Map<String, Object>)user1_data.get("organizations");
+        assertEquals( 2, user1_data_orgs.size());
+
+    }
 }


### PR DESCRIPTION
- ExportAdmins now does not halt when getOrganizationsForAdminUser() has uniqueness violation
- ImportAdmins logic now only creates an organization if it does not already exist
- Additional test assertion to cover managementService.getAdminUsersForOrganization()