### PR TITLE
Use the correct parameter name for setting the sstable size in compac…

### DIFF
--- a/stack/corepersistence/common/src/main/java/org/apache/usergrid/persistence/core/astyanax/MultiTennantColumnFamilyDefinition.java
+++ b/stack/corepersistence/common/src/main/java/org/apache/usergrid/persistence/core/astyanax/MultiTennantColumnFamilyDefinition.java
@@ -79,7 +79,7 @@ public class MultiTennantColumnFamilyDefinition {
     public static final String CACHE_OPTION = "caching";
     public static final String COMPACTION_STRATEGY = "compaction_strategy";
     public static final String COMPACTION_STRATEGY_OPTIONS = "compaction_strategy_options";
-    public static final String COMPACTION_SSTABLE_SIZE = "compaction_strategy_options";
+    public static final String COMPACTION_SSTABLE_SIZE = "sstable_size_in_mb";
     public static final String BLOOM_FILTER_FP = "sstable_size_in_mb";
 
 


### PR DESCRIPTION
…tion strategy options for CFs.

@tnine FYI.. this should also be merged in two-dot-o branch.  When the schema is getting created using /system/database/setup with Cassandra 2.0.x, it fails due to this setting being unrecognized for compaction strategy options.