### PR TITLE
Ensure that the input application name does not contain characters th…

### DIFF
--- a/stack/rest/src/main/java/org/apache/usergrid/rest/organizations/OrganizationResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/organizations/OrganizationResource.java
@@ -125,14 +125,15 @@ public class OrganizationResource extends AbstractContextResource {
     }
 
 
-    @Path("{applicationName: [^<>/]+}")
+    @Path("{applicationName}")
     public ApplicationResource getApplicationByName( @PathParam("applicationName") String applicationName )
             throws Exception {
-
         if ( "options".equalsIgnoreCase( request.getMethod() ) ) {
             throw new NoOpException();
         }
-
+        if (!isSafe(applicationName)) {
+            throw new IllegalArgumentException("Invalid application name");
+        }
         String orgAppName = PathingUtils.assembleAppName( organizationName, applicationName );
         UUID applicationId = emf.lookupApplication( orgAppName );
         if ( applicationId == null ) {
@@ -143,21 +144,21 @@ public class OrganizationResource extends AbstractContextResource {
     }
 
 
-    @Path("applications/{applicationName: [^<>/]+}")
+    @Path("applications/{applicationName}")
     public ApplicationResource getApplicationByName2( @PathParam("applicationName") String applicationName )
             throws Exception {
         return getApplicationByName( applicationName );
     }
 
 
-    @Path("apps/{applicationName: [^<>/]+}")
+    @Path("apps/{applicationName}")
     public ApplicationResource getApplicationByName3( @PathParam("applicationName") String applicationName )
             throws Exception {
         return getApplicationByName( applicationName );
     }
 
 
-    @Path("a/{applicationName: [^<>/]+}")
+    @Path("a/{applicationName}")
     public ApplicationResource getApplicationByName4( @PathParam("applicationName") String applicationName )
             throws Exception {
         return getApplicationByName( applicationName );

--- a/stack/rest/src/main/java/org/apache/usergrid/rest/organizations/OrganizationResource.java
+++ b/stack/rest/src/main/java/org/apache/usergrid/rest/organizations/OrganizationResource.java
@@ -125,7 +125,7 @@ public class OrganizationResource extends AbstractContextResource {
     }
 
 
-    @Path("{applicationName}")
+    @Path("{applicationName: [^<>/]+}")
     public ApplicationResource getApplicationByName( @PathParam("applicationName") String applicationName )
             throws Exception {
 
@@ -143,21 +143,21 @@ public class OrganizationResource extends AbstractContextResource {
     }
 
 
-    @Path("applications/{applicationName}")
+    @Path("applications/{applicationName: [^<>/]+}")
     public ApplicationResource getApplicationByName2( @PathParam("applicationName") String applicationName )
             throws Exception {
         return getApplicationByName( applicationName );
     }
 
 
-    @Path("apps/{applicationName}")
+    @Path("apps/{applicationName: [^<>/]+}")
     public ApplicationResource getApplicationByName3( @PathParam("applicationName") String applicationName )
             throws Exception {
         return getApplicationByName( applicationName );
     }
 
 
-    @Path("a/{applicationName}")
+    @Path("a/{applicationName: [^<>/]+}")
     public ApplicationResource getApplicationByName4( @PathParam("applicationName") String applicationName )
             throws Exception {
         return getApplicationByName( applicationName );

--- a/stack/rest/src/test/java/org/apache/usergrid/rest/management/organizations/OrganizationResourceIT.java
+++ b/stack/rest/src/test/java/org/apache/usergrid/rest/management/organizations/OrganizationResourceIT.java
@@ -16,31 +16,26 @@
  */
 package org.apache.usergrid.rest.management.organizations;
 
-
 import com.sun.jersey.api.client.UniformInterfaceException;
-import org.apache.usergrid.rest.management.organizations.OrganizationsResource;
-
-import java.net.URLEncoder;
-import java.util.HashMap;
-import java.util.Map;
-
-import javax.ws.rs.core.MediaType;
-
-import org.codehaus.jackson.JsonNode;
-import org.junit.Rule;
-import org.junit.Test;
+import junit.framework.Assert;
 import org.apache.usergrid.cassandra.Concurrent;
 import org.apache.usergrid.management.OrganizationInfo;
 import org.apache.usergrid.rest.AbstractRestIT;
 import org.apache.usergrid.rest.TestContextSetup;
-
-import junit.framework.Assert;
+import org.codehaus.jackson.JsonNode;
+import org.junit.Rule;
+import org.junit.Test;
 import org.usergrid.java.client.response.ApiResponse;
 
-import static junit.framework.Assert.fail;
+import javax.ws.rs.core.MediaType;
+import java.net.URLEncoder;
+import java.util.HashMap;
+import java.util.Map;
+
+
+import static org.apache.usergrid.utils.MapUtils.hashMap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
-import static org.apache.usergrid.utils.MapUtils.hashMap;
 
 
 @Concurrent()
@@ -98,7 +93,7 @@ public class OrganizationResourceIT extends AbstractRestIT {
         try {
             final String encodedAppName = URLEncoder.encode("<bob>", "UTF-8");
             resource().path("/applications/" + encodedAppName).get( String.class );
-            fail("Expected exception");
+            Assert.fail("Expected exception");
         }
         catch (UniformInterfaceException e) {
             final ApiResponse response = e.getResponse().getEntity(ApiResponse.class);


### PR DESCRIPTION
…at can be used to inject malicious content.

The application name is repeated as-is in the response message if the oragnization/application cannot be found when OrganizationApplicationNotFoundException is thrown. This could be used for an XSS attack.