### PR TITLE
Additional fixes to ExportAdmins & ImportAdmins

### DIFF
--- a/stack/tools/src/main/java/org/apache/usergrid/tools/ExportAdmins.java
+++ b/stack/tools/src/main/java/org/apache/usergrid/tools/ExportAdmins.java
@@ -80,6 +80,8 @@ public class ExportAdmins extends ExportingToolBase {
     private int readThreadCount;
 
     AtomicInteger userCount = new AtomicInteger( 0 );
+    
+    boolean ignoreInvalidUsers = false; // true to ignore users with no credentials or orgs
    
     
     /**
@@ -335,9 +337,10 @@ public class ExportAdmins extends ExportingToolBase {
 
                     String actionTaken = "Processed";
 
-                    if (task.orgNamesByUuid.isEmpty()
+                    if (ignoreInvalidUsers && (task.orgNamesByUuid.isEmpty()
                             || task.dictionariesByName.isEmpty()
-                            || task.dictionariesByName.get( "credentials" ).isEmpty()) {
+                            || task.dictionariesByName.get( "credentials" ).isEmpty())) {
+                        
                         actionTaken = "Ignored";
                         
                     } else {

--- a/stack/tools/src/main/java/org/apache/usergrid/tools/ExportAdmins.java
+++ b/stack/tools/src/main/java/org/apache/usergrid/tools/ExportAdmins.java
@@ -61,15 +61,25 @@ import static org.apache.usergrid.persistence.cassandra.CassandraService.MANAGEM
  *    cassandra.lock.keyspace=My_Usergrid_Locks
  */
 public class ExportAdmins extends ExportingToolBase {
-
+    
     static final Logger logger = LoggerFactory.getLogger( ExportAdmins.class );
+    
     public static final String ADMIN_USERS_PREFIX = "admin-users";
     public static final String ADMIN_USER_METADATA_PREFIX = "admin-user-metadata";
-    private static final String READ_THREAD_COUNT = "readThreads";
-    private Map<String, List<Org>> orgMap = new HashMap<String, List<Org>>(80000);
-    private int readThreadCount;
+   
+    // map admin user UUID to list of organizations to which user belongs
+    private Map<UUID, List<Org>> userToOrgsMap = new HashMap<UUID, List<Org>>(50000);
+
+    private Map<String, UUID> orgNameToUUID = new HashMap<String, UUID>(50000);
     
-    AtomicInteger count = new AtomicInteger( 0 );
+    private Set<UUID> orgsWritten = new HashSet<UUID>(50000);
+    
+    private Set<UUID> duplicateOrgs = new HashSet<UUID>();
+    
+    private static final String READ_THREAD_COUNT = "readThreads";
+    private int readThreadCount;
+
+    AtomicInteger userCount = new AtomicInteger( 0 );
    
     
     /**
@@ -173,7 +183,7 @@ public class ExportAdmins extends ExportingToolBase {
         while ( !done ) {
             writeThread.join( 10000, 0 );
             done = !writeThread.isAlive();
-            logger.info( "Wrote {} users", count.get() );
+            logger.info( "Wrote {} users", userCount.get() );
         }
     }
     
@@ -211,10 +221,11 @@ public class ExportAdmins extends ExportingToolBase {
             organizations = em.searchCollection( em.getApplicationRef(), "groups", query );
             for ( Entity organization : organizations.getEntities() ) {
                 execService.submit( new OrgMapWorker( organization ) );
+                count++;
             }
-            count++;
+             
             if ( count % 1000 == 0 ) {
-                logger.info("Processed {} orgs for org map", count);
+                logger.info("Queued {} org map workers", count);
             }
             query.setCursor( organizations.getCursor() );
         }
@@ -222,8 +233,10 @@ public class ExportAdmins extends ExportingToolBase {
 
         execService.shutdown();
         while ( !execService.awaitTermination( 10, TimeUnit.SECONDS ) ) {
-            logger.info("Processed {} orgs for map", orgMap.size() );
+            logger.info( "Processed {} orgs for map", userToOrgsMap.size() );
         }
+        
+        logger.info("Org map complete, counted {} organizations", count);
     }
 
 
@@ -239,17 +252,33 @@ public class ExportAdmins extends ExportingToolBase {
             try {
                 final String orgName = orgEntity.getProperty( "path" ).toString();
                 final UUID orgId = orgEntity.getUuid();
+                
                 for (UserInfo user : managementService.getAdminUsersForOrganization( orgEntity.getUuid() )) {
                     try {
                         Entity admin = managementService.getAdminUserEntityByUuid( user.getUuid() );
-                        List<Org> orgs = orgMap.get( admin.getProperty( "username" ) );
-                        if (orgs == null) {
-                            orgs = new ArrayList<Org>();
-                            orgMap.put( admin.getProperty( "username" ).toString().toLowerCase(), orgs );
-                        }
-                        orgs.add( new Org( orgId, orgName ) );
+                        Org org = new Org( orgId, orgName );
 
-                        //logger.debug("Added org {} for user {}", orgName, admin.getProperty( "username" ));
+                        synchronized (userToOrgsMap) {
+                            List<Org> userOrgs = userToOrgsMap.get( admin.getUuid() );
+                            if (userOrgs == null) {
+                                userOrgs = new ArrayList<Org>();
+                                userToOrgsMap.put( admin.getUuid(), userOrgs );
+                            }
+                            userOrgs.add( org );
+                        }
+
+                        synchronized (orgNameToUUID) {
+                            UUID existingOrgId = orgNameToUUID.get( orgName );
+                            ;
+                            if (existingOrgId != null && !orgId.equals( existingOrgId )) {
+                                if ( !duplicateOrgs.contains( orgId )) {
+                                    logger.info( "Org {}:{} is a duplicate", orgId, orgName );
+                                    duplicateOrgs.add(orgId);
+                                }
+                            } else {
+                                orgNameToUUID.put( orgName, orgId );
+                            }
+                        }
 
                     } catch (Exception e) {
                         logger.warn( "Cannot get orgs for userId {}", user.getUuid() );
@@ -301,10 +330,33 @@ public class ExportAdmins extends ExportingToolBase {
                     AdminUserWriteTask task = new AdminUserWriteTask();
                     task.adminUser = entity;
 
-                    addDictionariesToTask(  task, entity );
+                    addDictionariesToTask( task, entity );
                     addOrganizationsToTask( task );
 
-                    writeQueue.add( task );
+                    String actionTaken = "Processed";
+
+                    if (task.orgNamesByUuid.isEmpty()
+                            || task.dictionariesByName.isEmpty()
+                            || task.dictionariesByName.get( "credentials" ).isEmpty()) {
+                        actionTaken = "Ignored";
+                        
+                    } else {
+                        writeQueue.add( task );
+                    }
+
+                    Map<String, Object> creds = (Map<String, Object>) (task.dictionariesByName.isEmpty() ? 
+                                                0 : task.dictionariesByName.get( "credentials" ));
+                    
+                    logger.error( "{} admin user {}:{}:{} has organizations={} dictionaries={} credentials={}",
+                            new Object[]{
+                                    actionTaken,
+                                    task.adminUser.getProperty( "username" ),
+                                    task.adminUser.getProperty( "email" ),
+                                    task.adminUser.getUuid(),
+                                    task.orgNamesByUuid.size(),
+                                    task.dictionariesByName.size(),
+                                    creds == null ? 0 : creds.size()
+                            } ); 
 
                 } catch ( Exception e ) {
                     logger.error("Error reading data for user " + uuid, e );
@@ -327,20 +379,8 @@ public class ExportAdmins extends ExportingToolBase {
 
             Map<Object, Object> credentialsDictionary = em.getDictionaryAsMap( entity, "credentials" );
 
-            if ( credentialsDictionary != null && !credentialsDictionary.isEmpty() ) {
+            if ( credentialsDictionary != null ) {
                 task.dictionariesByName.put( "credentials", credentialsDictionary );
-
-                if (credentialsDictionary.get( "password" ) == null) {
-                    logger.error( "User {}:{} has no password in credential dictionary",
-                        new Object[]{task.adminUser.getName(), task.adminUser.getUuid()} );
-                }
-                if (credentialsDictionary.get( "secret" ) == null) {
-                    logger.error( "User {}:{} has no secret in credential dictionary",
-                        new Object[]{task.adminUser.getName(), task.adminUser.getUuid()} );
-                }
-            } else {
-                logger.error( "User {}:{} has no or empty credentials dictionary",
-                    new Object[]{task.adminUser.getName(), task.adminUser.getUuid()} );
             }
         }
 
@@ -348,21 +388,16 @@ public class ExportAdmins extends ExportingToolBase {
 
             task.orgNamesByUuid = managementService.getOrganizationsForAdminUser( task.adminUser.getUuid() );
 
-            List<Org> orgs = orgMap.get( task.adminUser.getProperty( "username" ).toString().toLowerCase() );
+            List<Org> orgs = userToOrgsMap.get( task.adminUser.getProperty( "username" ).toString().toLowerCase() );
             
             if ( orgs != null && task.orgNamesByUuid.size() < orgs.size() ) {
+                
+                // list of orgs from getOrganizationsForAdminUser() is less than expected, use userToOrgsMap
                 BiMap<UUID, String> bimap = HashBiMap.create();
                 for (Org org : orgs) {
                     bimap.put( org.orgId, org.orgName );
                 }
                 task.orgNamesByUuid = bimap;
-            }
-            
-            if ( task.orgNamesByUuid.isEmpty() ) {
-                logger.error("{}:{}:{} has no orgs", new Object[] {
-                        task.adminUser.getProperty("username"), 
-                        task.adminUser.getProperty("email"), 
-                        task.adminUser.getUuid() } );
             }
         }
     }
@@ -425,7 +460,7 @@ public class ExportAdmins extends ExportingToolBase {
                         task.adminUser.getProperty("email"),
                         task.adminUser.getUuid() } );
 
-                    count.addAndGet( 1 );
+                    userCount.addAndGet( 1 );
 
                 } catch (InterruptedException e) {
                     throw new Exception("Interrupted", e);
@@ -438,7 +473,7 @@ public class ExportAdmins extends ExportingToolBase {
             usersFile.writeEndArray();
             usersFile.close();
 
-            logger.info( "Exported TOTAL {} admin users", count );
+            logger.info( "Exported TOTAL {} admin users and {} organizations", userCount.get(), orgsWritten.size() );
         }
 
 
@@ -490,7 +525,9 @@ public class ExportAdmins extends ExportingToolBase {
 
                 jg.writeEndObject();
                 
-                logger.debug( "Exported organization {}:{}", uuid, orgs.get( uuid ) );
+                synchronized (orgsWritten) {
+                    orgsWritten.add( uuid );
+                }
             }
 
             jg.writeEndArray();

--- a/stack/tools/src/main/java/org/apache/usergrid/tools/ExportAdmins.java
+++ b/stack/tools/src/main/java/org/apache/usergrid/tools/ExportAdmins.java
@@ -489,6 +489,8 @@ public class ExportAdmins extends ExportingToolBase {
                 jg.writeObject( orgs.get( uuid ) );
 
                 jg.writeEndObject();
+                
+                logger.debug( "Exported organization {}:{}", uuid, orgs.get( uuid ) );
             }
 
             jg.writeEndArray();

--- a/stack/tools/src/main/java/org/apache/usergrid/tools/ImportAdmins.java
+++ b/stack/tools/src/main/java/org/apache/usergrid/tools/ImportAdmins.java
@@ -462,7 +462,13 @@ public class ImportAdmins extends ToolBase {
                     } else { // org exists, add original user to it
                         try {
                             managementService.addAdminUserToOrganization( userInfo, orgInfo, false );
-                            logger.debug( "Added user {} to org {}", new Object[]{user.getEmail(), orgName} );
+                            logger.debug( "Added to org user {}:{}:{}",
+                                    new Object[]{
+                                            orgInfo.getName(),
+                                            user.getUsername(),
+                                            user.getEmail(),
+                                            user.getUuid()
+                                    });
 
                         } catch (Exception e) {
                             logger.error( "Error Adding user {} to org {}", new Object[]{user.getEmail(), orgName} );
@@ -533,7 +539,9 @@ public class ImportAdmins extends ToolBase {
                             logger.debug( "Created new org {} for user {}:{}:{} from duplicate user {}:{}",
                                 new Object[]{
                                         orgInfo.getName(),
-                                        originalUser.getUuid(), originalUser.getUsername(), originalUser.getEmail(),
+                                        originalUser.getUsername(), 
+                                        originalUser.getEmail(),
+                                        originalUser.getUuid(), 
                                         dup.username, dup.email
                                 });
 
@@ -546,7 +554,9 @@ public class ImportAdmins extends ToolBase {
                             logger.debug( "Added to org user {}:{}:{} from duplicate user {}:{}",
                                     new Object[]{
                                             orgInfo.getName(),
-                                            originalUser.getUuid(), originalUser.getUsername(), originalUser.getEmail(),
+                                            originalUser.getUsername(), 
+                                            originalUser.getEmail(),
+                                            originalUser.getUuid(), 
                                             dup.username, dup.email
                                     });
 
@@ -686,7 +696,7 @@ public class ImportAdmins extends ToolBase {
 
             while (!done) {
                 try {
-                    ImportMetadataTask task = this.workQueue.poll(30, TimeUnit.SECONDS);
+                    ImportMetadataTask task = this.workQueue.poll( 30, TimeUnit.SECONDS );
 
                     if (task == null) {
                         logger.warn("Reading from metadata queue was null!");
@@ -694,11 +704,11 @@ public class ImportAdmins extends ToolBase {
                         Thread.sleep(1000);
                         continue;
                     }
-                    metadataEmptyCount.set(0);
+                    metadataEmptyCount.set( 0 );
                     
                     long startTime = System.currentTimeMillis();
                     
-                    importEntityMetadata(em, task.entityRef, task.metadata);
+                    importEntityMetadata( em, task.entityRef, task.metadata );
                     
                     long stopTime = System.currentTimeMillis();
                     long duration = stopTime - startTime;
@@ -770,7 +780,7 @@ public class ImportAdmins extends ToolBase {
                         em.create(uuid, type, entityProps);
 
                         logger.debug( "Imported admin user {}:{}:{}",
-                            new Object[] { uuid, entityProps.get( "username" ), entityProps.get("email") } );
+                            new Object[] { entityProps.get( "username" ), entityProps.get("email"), uuid } );
 
                         userCount.getAndIncrement();
                         auditQueue.put(entityProps);
@@ -805,7 +815,10 @@ public class ImportAdmins extends ToolBase {
         private void handleDuplicateAccount(EntityManager em, String dupProperty, Map<String, Object> entityProps ) {
 
             logger.info( "Processing duplicate user {}:{}:{} with duplicate {}", new Object[]{
-                    entityProps.get( "uuid" ), entityProps.get( "username" ), entityProps.get( "email" ), dupProperty} );
+                    entityProps.get( "username" ), 
+                    entityProps.get( "email" ), 
+                    entityProps.get( "uuid" ), 
+                    dupProperty} );
            
             UUID dupUuid = UUID.fromString( entityProps.get("uuid").toString() );
             try {

--- a/stack/tools/src/main/java/org/apache/usergrid/tools/ImportAdmins.java
+++ b/stack/tools/src/main/java/org/apache/usergrid/tools/ImportAdmins.java
@@ -636,7 +636,7 @@ public class ImportAdmins extends ToolBase {
                     long duration = stopTime - startTime;
                     durationSum += duration;
 
-                    //logger.debug( "Audited {}th admin", count );
+                    //logger.debug( "Audited {}th admin", userCount );
                     
                     if ( count % 100 == 0 ) {
                         logger.info( "Audited {}. Average Audit Rate: {}(ms)", count, durationSum / count );

--- a/stack/tools/src/main/resources/log4j.properties
+++ b/stack/tools/src/main/resources/log4j.properties
@@ -26,7 +26,7 @@ log4j.appender.stdout=org.apache.log4j.ConsoleAppender
 log4j.appender.stdout.layout=org.apache.log4j.PatternLayout
 log4j.appender.stdout.layout.ConversionPattern=%d %p (%t) [%c] - %m%n
 
-log4j.logger.org.apache.usergrid.tools=INFO
+log4j.logger.org.apache.usergrid.tools=DEBUG
 
 log4j.logger.org.apache.usergrid.management.cassandra=WARN
 log4j.logger.org.apache.usergrid.persistence.cassandra.DB=WARN

--- a/stack/tools/src/test/resources/admin-user-metadata.usergrid-management.1433331614293.json
+++ b/stack/tools/src/test/resources/admin-user-metadata.usergrid-management.1433331614293.json
@@ -81,5 +81,57 @@
         }
       }
     }
+  }, 
+  "USER_UUID_3" : {
+    "activities": [],
+    "devices": [],
+    "feed": [
+      "4c8fee64-09e5-11e5-b3c6-57cd4e12c0b1"
+    ],
+    "groups": [
+      "4c88c26a-09e5-11e5-8a66-594dd93a503d"
+    ],
+    "roles": [],
+    "connections": {},
+    "organizations": [
+      {
+        "uuid": "ORG_UUID_3",
+        "name": "ORG_NAME_3"
+      }
+    ],
+    "dictionaries": {
+      "credentials": {
+        "mongo_pwd": {
+          "recoverable": true,
+          "encrypted": false,
+          "secret": "e7b4fc7db5b97088997e44eced015d42",
+          "hashType": null,
+          "created": 1433331614067,
+          "cryptoChain": [
+            "plaintext"
+          ]
+        },
+        "password": {
+          "recoverable": false,
+          "encrypted": true,
+          "secret": "JDJhJDA5JER0RTdNSldMRjkxSUlJVm5hZWJMTy5DelFLemwvd2tXdUttaHViZWdyRjRURVdxYk5TUGJt",
+          "hashType": null,
+          "created": 1433331614018,
+          "cryptoChain": [
+            "bcrypt"
+          ]
+        },
+        "secret": {
+          "recoverable": true,
+          "encrypted": false,
+          "secret": "YWQ6Rx9A-m5U-TihpkPVS4PmyQO4qig",
+          "hashType": null,
+          "created": 1433331614067,
+          "cryptoChain": [
+            "plaintext"
+          ]
+        }
+      }
+    }
   }
 }

--- a/stack/tools/src/test/resources/admin-users.usergrid-management.1433331614293.json
+++ b/stack/tools/src/test/resources/admin-users.usergrid-management.1433331614293.json
@@ -20,4 +20,16 @@
   "activated" : true,
   "confirmed" : true,
   "disabled" : false
+}, {
+  "uuid" : "USER_UUID_3",
+  "type" : "user",
+  "name" : "USER_NAME_3",
+  "created" : 1433331614002,
+  "modified" : 1433331614002,
+  "username" : "USER_NAME_3",
+  "comment" : "this is a duplicate user, has same email address as user2",
+  "email" : "USER_NAME_2@example.com",
+  "activated" : true,
+  "confirmed" : true,
+  "disabled" : false
 } ]


### PR DESCRIPTION
ImportAdmins will now merge duplicate user accounts and give the merged account a union of the orgs in the duplicates. ExportAdmins no longer exports users with no organizations or credentials. Both tools now use more consistent logging.