### PR TITLE
ExportAppTest fixes

### DIFF
--- a/stack/core/src/main/java/org/apache/usergrid/utils/JsonUtils.java
+++ b/stack/core/src/main/java/org/apache/usergrid/utils/JsonUtils.java
@@ -173,7 +173,7 @@ public class JsonUtils {
                     return UUID.fromString( s );
                 }
                 catch ( IllegalArgumentException e ) {
-                    LOG.warn( "Argument to UUID.fromString({}) was invalid.", s, e );
+                    LOG.debug( "Argument to UUID.fromString({}) was invalid.", s, e );
                 }
             }
         }

--- a/stack/tools/src/main/resources/toolsApplicationContext.xml
+++ b/stack/tools/src/main/resources/toolsApplicationContext.xml
@@ -58,5 +58,5 @@
 		</property>
 	</bean>
 
-	<import resource="classpath:/usergrid-rest-context.xml"/>
+	<import resource="classpath:/usergrid-services-context.xml"/>
 </beans>

--- a/stack/tools/src/test/java/org/apache/usergrid/tools/ExportAppTest.java
+++ b/stack/tools/src/test/java/org/apache/usergrid/tools/ExportAppTest.java
@@ -20,24 +20,12 @@ import org.apache.commons.lang.RandomStringUtils;
 import org.apache.usergrid.ServiceITSetup;
 import org.apache.usergrid.ServiceITSetupImpl;
 import org.apache.usergrid.ServiceITSuite;
-import org.apache.usergrid.management.ApplicationInfo;
-import org.apache.usergrid.management.OrganizationOwnerInfo;
-import org.apache.usergrid.persistence.Entity;
-import org.apache.usergrid.persistence.EntityManager;
 import org.junit.ClassRule;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import rx.Scheduler;
-import rx.schedulers.Schedulers;
 
 import java.io.File;
 import java.io.FileFilter;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -86,7 +74,8 @@ public class ExportAppTest {
         }, false );
 
         logger.info( "100 read and 100 write threads = " + (System.currentTimeMillis() - start) / 1000 + "s" );
-        
+
+        // result should be between 1 and 100 files of each type
         File exportDir = new File(directoryName);
         assertTrue( getFileCount( exportDir, "entities"    ) > 0 );
         assertTrue( getFileCount( exportDir, "connections" ) > 0 );
@@ -96,15 +85,18 @@ public class ExportAppTest {
         File exportDir1 = new File(directoryName + "1");
         exportApp.startTool( new String[]{
                 "-application", orgName + "/" + appName,
-                "-writeThreads", "1",
+                "-writeThreads", "5",
                 "-host", "localhost:" + ServiceITSuite.cassandraResource.getRpcPort(),
                 "-outputDir", directoryName + "1"
         }, false );
 
-        logger.info( "1 thread time = " + (System.currentTimeMillis() - start) / 1000 + "s" );
+        logger.info( "5 thread time = " + (System.currentTimeMillis() - start) / 1000 + "s" );
 
-        assertEquals( 1, getFileCount( exportDir1, "entities" ));
-        assertEquals( 1, getFileCount( exportDir1, "connections" ));
+        // result should be between 1 and 10 files of each type
+        assertTrue( getFileCount( exportDir1, "entities" ) > 0 );
+        assertTrue( getFileCount( exportDir1, "connections" ) > 0 );
+        assertTrue( getFileCount( exportDir1, "entities" ) <= 5 );
+        assertTrue( getFileCount( exportDir1, "connections" ) <= 5 );
     }
 
     private static int getFileCount(File exportDir, final String ext ) {


### PR DESCRIPTION
Tools should depend on Services not REST, JsonUtils should chill out on the warnings and ExportAppTest now needs at least 5 writeThreads to keep up with Usergrid reads (not sure why).